### PR TITLE
updates suite à retours de l'urscop

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
     ecmaVersion: 2020
   },
   rules: {
+    'no-irregular-whitespace': 'off',
     'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off'
   }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # multi-site-simulators
 
-A widget to simulate shares at multi.
+A widget to simulate shares in a french cooperative (SCOP).
 
 That's a widget you can include in any html page...
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,15 @@ Widgets need two files in order to work :
 - `app.js`
 - `app.css`
 
-Add those two files to your html head.
+Add those two files to your html head, like this if the widget code is deployed on `https://multi-site-simulator-test.netlify.app`:
 
-Widgets can now be called directly into the page as custom html elements.
+```html
+<script src="https://multi-site-simulator-test.netlify.app/js/app.js" type="text/javascript"></script>
+
+<link type="text/css" href="ttps://multi-site-simulator-test.netlify.app/js/app.css" rel="stylesheet">
+```
+
+Widgets can then be called directly into the page as custom html elements.
 
 ---
 

--- a/src/components/InfosDrawer.vue
+++ b/src/components/InfosDrawer.vue
@@ -37,10 +37,10 @@
               la part <strong>entreprise</strong> : ce sont les réserves impartageables de l'entreprise, <strong>au minimum 16% des bénéfices</strong> ;
             </li>
             <li>
-              la part <strong>travail</strong> : participation des salariés aux bénéfices de l´entreprise, <strong>au minimum 25% des bénéfices</strong> ;
+              la part <strong>travail</strong> : participation brute des salariés aux bénéfices de l´entreprise, <strong>au minimum 25% des bénéfices</strong> ;
             </li>
             <li>
-              la part <strong>capital</strong>, ou ce qui est redistribué en dividendes aux associé·e·s. Cette part doit être inférieure à la fois à la part dévolue aux réserves et à la part dévolue à la participation, <strong>au maximum 33% des bénéfices</strong> ;
+              la part <strong>capital</strong>, ou ce qui est redistribué en intérêts aux part aux associé·e·s. Cette part doit être inférieure à la fois à la part dévolue aux réserves et à la part dévolue à la participation, <strong>au maximum 33% des bénéfices</strong> ;
             </li>
             <li>
               Attention toutefois, <strong>le montant de la prime de participation est plafonné</strong> et ne doit donc pas dépasser un certain plafond. En 2021, le montant maximum de la prime de participation est de 30 852€

--- a/src/components/InfosDrawer.vue
+++ b/src/components/InfosDrawer.vue
@@ -30,17 +30,17 @@
             Juridiquement, une Scop (Société coopérative et participative) est une société coopérative de forme SA, SARL ou SAS, dont les salarié•e•s sont les associé•e•s majoritaires et le pouvoir y est exercé démocratiquement.
           </p>
           <p>
-            <strong>Les bénéfices de la Scop sont dès le 1er euro obligatoirement répartis en trois parts :</strong>
+            <strong>Les excédents nets de gestion de la Scop sont dès le 1er euro obligatoirement répartis en trois parts :</strong>
           </p>
           <ul>
             <li>
-              la part <strong>entreprise</strong> : ce sont les réserves impartageables de l'entreprise, <strong>au minimum 16% des bénéfices</strong> ;
+              la part <strong>entreprise</strong> : ce sont les réserves impartageables de l'entreprise, <strong>au minimum 16% des excédents nets de gestion</strong> ;
             </li>
             <li>
-              la part <strong>travail</strong> : participation brute des salariés aux bénéfices de l´entreprise, <strong>au minimum 25% des bénéfices</strong> ;
+              la part <strong>travail</strong> : participation brute des salariés aux excédents nets de gestion de l´entreprise, <strong>au minimum 25% des excédents nets de gestion</strong> ;
             </li>
             <li>
-              la part <strong>capital</strong>, ou ce qui est redistribué en intérêts aux part aux associé·e·s. Cette part doit être inférieure à la fois à la part dévolue aux réserves et à la part dévolue à la participation, <strong>au maximum 33% des bénéfices</strong> ;
+              la part <strong>capital</strong>, ou ce qui est redistribué en intérêts aux part aux associé·e·s. Cette part doit être inférieure à la fois à la part dévolue aux réserves et à la part dévolue à la participation, <strong>au maximum 33% des excédents nets de gestion</strong> ;
             </li>
             <li>
               Attention toutefois, <strong>le montant de la prime de participation est plafonné</strong> et ne doit donc pas dépasser un certain plafond. En 2021, le montant maximum de la prime de participation est de 30 852€

--- a/src/components/InfosDrawer.vue
+++ b/src/components/InfosDrawer.vue
@@ -37,7 +37,7 @@
               la part <strong>entreprise</strong> : ce sont les réserves impartageables de l'entreprise, <strong>au minimum 16% des excédents nets de gestion</strong> ;
             </li>
             <li>
-              la part <strong>travail</strong> : participation brute des salariés aux excédents nets de gestion de l´entreprise, <strong>au minimum 25% des excédents nets de gestion</strong> ;
+              la part <strong>travail</strong> : participation brute aux salariés aux excédents nets de gestion de l´entreprise, <strong>au minimum 25% des excédents nets de gestion</strong> ;
             </li>
             <li>
               la part <strong>capital</strong>, ou ce qui est redistribué en intérêts aux part aux associé·e·s. Cette part doit être inférieure à la fois à la part dévolue aux réserves et à la part dévolue à la participation, <strong>au maximum 33% des excédents nets de gestion</strong> ;

--- a/src/components/InfosMethodo.vue
+++ b/src/components/InfosMethodo.vue
@@ -30,17 +30,17 @@
             Introduction
           </h5>
           <p>
-            Ce simulateur de répartition des excédents de gestion d'une Scop est un outil de type <i>widget</i> qui vise à jouer avec les différentes variables permmettant de calculer les parts de chaque personne impliquée dans la coopérative.
+            Ce simulateur de répartition des excédents nets de gestion d'une Scop est un outil de type <i>widget</i> qui vise à jouer avec les différentes variables permmettant de calculer les parts de chaque personne impliquée dans la coopérative.
           </p>
           <p>
             Nous avons tenté d'intégrer à ce simulateur toutes les obligations légales propres aux Scop, et d'en rendre l'usage le plus simple possible.
           </p>
           <p>
-            <strong>Pour rappel les bénéfices de la Scop sont obligatoirement répartis en trois parts :</strong>
+            <strong>Pour rappel les excédents nets de gestion de la Scop sont obligatoirement répartis en trois parts :</strong>
           </p>
           <ul>
             <li>
-              la part <strong>travail</strong> : participation brute des salarié•e•s aux bénéfices de l´entreprise (minimun 16%);
+              la part <strong>travail</strong> : participation brute des salarié•e•s aux excédents nets de gestion de l´entreprise (minimun 16%);
             </li>
             <li>
               la part <strong>entreprise</strong> : ce sont les réserves impartageables de l'entreprise (minimum 25%);
@@ -57,7 +57,7 @@
           </p>
           <ul>
             <li>
-              <strong>le montant des excédents de gestion sur l'exercice</strong> ;
+              <strong>le montant des excédents nets de gestion sur l'exercice</strong> ;
             </li>
             <li>
               <strong>le pourcentage des parts réserves, travail et capital</strong> ;
@@ -76,9 +76,11 @@
             Ce <i>widget</i> est en <i>open source</i>. Il est librement réutilisable et intégrable dans n'importe quel site internet.
             <br>
             Pour plus d'infos vous pouvez vous reporter à
-            <strong><a href="https://github.com/multi-coop/multi-site-simulator" target="_blank">
+            <strong>
+              <a href="https://github.com/multi-coop/multi-site-simulator" target="_blank">
               la documentation
-             </a></strong>.
+              </a>
+            </strong>.
           </p>
 
           <hr>

--- a/src/components/InfosMethodo.vue
+++ b/src/components/InfosMethodo.vue
@@ -110,7 +110,7 @@
               <strong>La part travail (prime de participation) de chaque salarié•e est uniquement indexée sur le temps de travail</strong> : par exemple si un•e salarié•e a travaillé 10 mois aux 4/5emes son temps de travail total cumulé sur l'exercice sera équivalent à 8 mois.
             </li>
             <li>
-              <strong>Ni l'anciennté ni le montant du salaire ne sont pris en compte pour calculer les dividendes ou la prime de participation.</strong>
+              <strong>Ni l'anciennté ni le montant du salaire ne sont pris en compte pour calculer les intérêts aux parts ou la prime de participation.</strong>
             </li>
           </ul>
 

--- a/src/components/InfosMethodo.vue
+++ b/src/components/InfosMethodo.vue
@@ -40,13 +40,13 @@
           </p>
           <ul>
             <li>
-              la part <strong>travail</strong> : participation des salarié•e•s aux bénéfices de l´entreprise (minimun 16%);
+              la part <strong>travail</strong> : participation brute des salarié•e•s aux bénéfices de l´entreprise (minimun 16%);
             </li>
             <li>
               la part <strong>entreprise</strong> : ce sont les réserves impartageables de l'entreprise (minimum 25%);
             </li>
             <li>
-              la part <strong>capital</strong>, ou ce qui est redistribué en dividendes aux associé·e·s (maximum 33%, et doit être inférieure aux parts réserves et travail).
+              la part <strong>capital</strong>, ou ce qui est redistribué aux associé·e·s au titre d'intérêts aux parts (maximum 33%, et doit être inférieure aux parts réserves et travail).
             </li>
             <li>
               En complément <strong>un•e associé•e ne peut détenir plus de 50% des parts sociales</strong>;

--- a/src/components/Member.vue
+++ b/src/components/Member.vue
@@ -74,7 +74,33 @@
           />
         </b-field> -->
 
-        <b-field
+        <ValueSliderMulti
+          :val="workTime"
+          :keyVal="'workTime'"
+          :sizeText="'small'"
+          :localChange="true"
+          @changeVal="updateMemberVal"
+          :debug="true"
+        />
+        <ValueSliderMulti
+          :val="yearTime"
+          :keyVal="'yearTime'"
+          :sizeText="'small'"
+          :localChange="true"
+          @changeVal="updateMemberVal"
+          :debug="false"
+        />
+        <ValueSliderMulti
+          :val="parts"
+          :keyVal="'parts'"
+          :sizeText="'small'"
+          :localChange="true"
+          @changeVal="updateMemberVal"
+          :debug="false"
+        />
+
+        <!--
+          <b-field
           :label="t('workTime')"
           class="mb-5"
           custom-class="is-small"
@@ -129,7 +155,7 @@
             :custom-formatter="(valTxt) => `${valTxt}.${t('partsShort')}`"
             @input="updateMember()"
           />
-        </b-field>
+        </b-field> -->
 
       </section>
 
@@ -257,8 +283,13 @@
 <script>
 import { mapState, mapGetters, mapActions } from 'vuex'
 
+import ValueSliderMulti from '@/components/ValueSliderMulti'
+
 export default {
   name: 'Member',
+  components: {
+    ValueSliderMulti
+  },
   props: {
     memberData: Object,
     keyMember: String
@@ -309,7 +340,12 @@ export default {
       benefsOptions: (state) => state.benefsOptions,
       reservesOptions: (state) => state.reservesOptions,
       participationOptions: (state) => state.participationOptions,
-      dividendesOptions: (state) => state.dividendesOptions
+      dividendesOptions: (state) => state.dividendesOptions,
+
+      workTimeOptions: (state) => state.workTimeOptions,
+      monthTimeOptions: (state) => state.monthTimeOptions,
+      partsOptions: (state) => state.partsOptions
+
     }),
     ...mapGetters({
       totals: 'totals',
@@ -355,6 +391,11 @@ export default {
         div: div,
         sum: Math.round(sum)
       }
+    },
+    updateMemberVal (event) {
+      // console.log('C - Member > updateMemberVal > event :', event)
+      this[event.space] = event.value
+      this.updateMember()
     },
     updateMember () {
       this.populateTeamMembers({ action: 'update', member: this.memberObject })

--- a/src/components/Member.vue
+++ b/src/components/Member.vue
@@ -80,7 +80,7 @@
           :sizeText="'small'"
           :localChange="true"
           @changeVal="updateMemberVal"
-          :debug="true"
+          :debug="false"
         />
         <ValueSliderMulti
           :val="yearTime"

--- a/src/components/Member.vue
+++ b/src/components/Member.vue
@@ -313,14 +313,19 @@ export default {
   },
   watch: {
     teamNeedsReset (next) {
-      // console.log('\nC - Member > watch > teamNeedsReset > next :', next)
-      // console.log('C - Member > watch > teamNeedsReset > this.keyMember :', this.keyMember)
       if (next.includes(this.keyMember)) {
-        // const memberDefault = this.getMemberDefault(this.keyMember)
+        // console.log('\nC - Member > watch > teamNeedsReset > next :', next)
+        // console.log('\nC - Member > watch > teamNeedsReset > this.keyMember :', this.keyMember)
+        const memberDefault = this.getMemberDefault(this.keyMember)
         // console.log('C - Member > watch > teamNeedsReset > memberDefault :', memberDefault)
-        this.name = this.dataMember.name
-        this.parts = this.dataMember.parts
-        this.workTime = this.dataMember.workTime
+        // this.name = this.dataMember.name
+        // this.parts = this.dataMember.parts
+        // this.workTime = this.dataMember.workTime
+        // this.yearTime = this.dataMember.yearTime
+        this.name = memberDefault.name
+        this.parts = memberDefault.parts
+        this.workTime = memberDefault.workTime
+        this.yearTime = memberDefault.yearTime
         this.deleteMemberFromNeedsReset(this.keyMember)
       }
     }
@@ -350,7 +355,7 @@ export default {
     ...mapGetters({
       totals: 'totals',
       getShares: 'getShares',
-      // getMemberDefault: 'getMemberDefault',
+      getMemberDefault: 'getMemberDefault',
       t: 'getTranslation'
     }),
     memberObject () {

--- a/src/components/MultiSimulator.vue
+++ b/src/components/MultiSimulator.vue
@@ -196,6 +196,7 @@
       </div>
     </div>
 
+    <!-- REINITIALIZATIONS -->
     <div class="columns is-centered mt-3">
       <div class="column is-one-third">
         <b-button

--- a/src/components/ValueSliderMulti.vue
+++ b/src/components/ValueSliderMulti.vue
@@ -66,7 +66,7 @@
           class="mt-2"
           @change="changeVal"
           expanded
-          :custom-formatter="(valTxt) => `${valTxt.toLocaleString()} ${unitText}`"
+          :custom-formatter="(valTxt) => `${valTxt.toLocaleString()} ${unitText}`"
         />
 
         <!-- SLIDER INPUT -->
@@ -81,7 +81,7 @@
           ticks
           :size="`is-small`"
           @input="changeVal"
-          :custom-formatter="(valTxt) => `${valTxt.toLocaleString()} ${unitText}`"
+          :custom-formatter="(valTxt) => `${valTxt.toLocaleString()} ${unitText}`"
         />
 
       </b-field>

--- a/src/components/ValueSliderMulti.vue
+++ b/src/components/ValueSliderMulti.vue
@@ -1,32 +1,76 @@
 <template>
   <section class="my-4">
+
+    <!-- DEBUGGING -->
+    <div
+      v-if="debug"
+      >
+      <div class="columns is-multiline">
+        <div class="column">
+          <p>
+            keyVal :
+            <code>{{ keyVal }}</code>
+          </p>
+          <p>
+            val :
+            <code>{{ val }}</code>
+          </p>
+          <p>
+            options :
+            <code>{{ options }}</code>
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <!-- SLIDER BLOCK -->
     <div
       class="block"
       >
-      <!-- {{ keyVal }} -
-      {{ repartDefaults }} -->
-      <!-- <b-field
-        :label="t(keyVal)"
-        class="mb-5"
-        >
+      <b-field>
+
+        <!-- LABEL -->
+        <template
+          slot="label"
+          >
+          <div
+            :class="`is-flex is-align-items-center`"
+            >
+            <span
+              :class="`is-${sizeText}`">
+              {{ t(keyVal) }}
+            </span>
+            <b-tooltip
+              :label="t('editValue')"
+              >
+              <b-button
+                icon-left="pencil"
+                size="is-small"
+                type="is-light"
+                class="ml-3 mb-0"
+                @click="showUserEdit = !showUserEdit"
+                >
+              </b-button>
+            </b-tooltip>
+          </div>
+        </template>
+
+        <!-- NUMBER INPUT -->
         <b-numberinput
+          v-show="showUserEdit"
           v-model="numberInput"
           :max="options.max"
           :min="options.min"
-          :step="options.ticks"
-          size="is-small"
+          :size="`is-small`"
           controls-position="compact"
-          controls-rounded
-          @input="changeVal"
+          @change="changeVal"
           expanded
-          :custom-formatter="(valTxt) => valTxt + options.unit"
+          :custom-formatter="(valTxt) => `${valTxt.toLocaleString()}.${t(options.unit)}`"
         />
-      </b-field> -->
-      <b-field
-        :label="t(keyVal)"
-        class=""
-        >
+
+        <!-- SLIDER INPUT -->
         <b-slider
+          v-show="!showUserEdit"
           v-model="numberInput"
           :max="options.max"
           :min="options.min"
@@ -34,10 +78,11 @@
           :tooltip="false"
           indicator
           ticks
-          size="is-small"
+          :size="`is-small`"
           @input="changeVal"
-          :custom-formatter="(valTxt) => `${valTxt.toLocaleString()}${options.unit}`"
+          :custom-formatter="(valTxt) => `${valTxt.toLocaleString()}.${t(options.unit)}`"
         />
+
       </b-field>
     </div>
   </section>
@@ -57,11 +102,10 @@ export default {
   name: 'ValueSliderMulti',
   props: {
     keyVal: String,
-    val: Number
-    // unit: String,
-    // min: Number,
-    // max: Number,
-    // ticks: Number
+    val: Number,
+    sizeText: String,
+    localChange: Boolean,
+    debug: Boolean
   },
   components: {
     // Slider,
@@ -69,6 +113,7 @@ export default {
   },
   data () {
     return {
+      showUserEdit: false,
       numberInput: 0,
       options: undefined
     }
@@ -86,20 +131,15 @@ export default {
     }
   },
   beforeMount () {
-    // this.numberInput = JSON.parse(JSON.stringify(this.val))
     this.numberInput = this.val
     this.options = this.getValOptions(this.keyVal)
   },
   computed: {
     ...mapState({
-      // benefsEntreprise: (state) => state.benefs
-      // valStore: (state) => state[this.keyVal]
       repartNeedsReset: 'repartNeedsReset',
       repartDefaults: 'repartDefaults'
     }),
     ...mapGetters({
-      // repartBenefs: 'repartBenefs',
-      // totals: 'totals',
       getVal: 'getKeyVal',
       getValOptions: 'getValOptions',
       t: 'getTranslation'
@@ -113,11 +153,15 @@ export default {
       populateRepart: 'populateRepart'
     }),
     changeVal (input) {
-      // this.numberInput = input
-      this.populateRepart({
+      const updated = {
         space: this.keyVal,
         value: this.numberInput
-      })
+      }
+      if (this.localChange) {
+        this.$emit('changeVal', updated)
+      } else {
+        this.populateRepart(updated)
+      }
     }
   }
 }

--- a/src/components/ValueSliderMulti.vue
+++ b/src/components/ValueSliderMulti.vue
@@ -65,7 +65,7 @@
           controls-position="compact"
           @change="changeVal"
           expanded
-          :custom-formatter="(valTxt) => `${valTxt.toLocaleString()}.${t(options.unit)}`"
+          :custom-formatter="(valTxt) => `${valTxt.toLocaleString()}.${unitText}`"
         />
 
         <!-- SLIDER INPUT -->
@@ -80,7 +80,7 @@
           ticks
           :size="`is-small`"
           @input="changeVal"
-          :custom-formatter="(valTxt) => `${valTxt.toLocaleString()}.${t(options.unit)}`"
+          :custom-formatter="(valTxt) => `${valTxt.toLocaleString()}.${unitText}`"
         />
 
       </b-field>
@@ -146,6 +146,9 @@ export default {
     }),
     valFromStore () {
       return this.getVal(this.keyVal)
+    },
+    unitText () {
+      return this.options.translateUnit ? this.t(this.options.unit) : this.options.unit
     }
   },
   methods: {

--- a/src/components/ValueSliderMulti.vue
+++ b/src/components/ValueSliderMulti.vue
@@ -63,9 +63,10 @@
           :min="options.min"
           :size="`is-small`"
           controls-position="compact"
+          class="mt-2"
           @change="changeVal"
           expanded
-          :custom-formatter="(valTxt) => `${valTxt.toLocaleString()}.${unitText}`"
+          :custom-formatter="(valTxt) => `${valTxt.toLocaleString()} ${unitText}`"
         />
 
         <!-- SLIDER INPUT -->
@@ -80,7 +81,7 @@
           ticks
           :size="`is-small`"
           @input="changeVal"
-          :custom-formatter="(valTxt) => `${valTxt.toLocaleString()}.${unitText}`"
+          :custom-formatter="(valTxt) => `${valTxt.toLocaleString()} ${unitText}`"
         />
 
       </b-field>
@@ -119,6 +120,10 @@ export default {
     }
   },
   watch: {
+    val (next) {
+      // console.log('C - ValueSliderMulti > watch > val > next :', next)
+      this.numberInput = next
+    },
     valFromStore (next) {
       // console.log('C - ValueSliderMulti > watch > valFromStore > prev :', prev)
       // console.log('C - ValueSliderMulti > watch > valFromStore > next :', next)
@@ -127,7 +132,9 @@ export default {
     repartNeedsReset (next) {
       // console.log('C - ValueSliderMulti > watch > repartNeedsReset > next :', next)
       // console.log('C - ValueSliderMulti > watch > repartNeedsReset > this.keyVal :', this.keyVal)
-      this.numberInput = this.repartDefaults[this.keyVal]
+      if (!this.localChange) {
+        this.numberInput = this.repartDefaults[this.keyVal]
+      }
     }
   },
   beforeMount () {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -9,21 +9,21 @@ export default new Vuex.Store({
 
     partValue: 25,
     partMax: 200,
-    partValueOptions: { min: 10, max: 80, minLimit: 20, maxLimit: 75, ticks: 5, unit: '€' },
+    partValueOptions: { min: 10, max: 80, minLimit: 20, maxLimit: 75, ticks: 5, unit: '€', translateUnit: false },
 
     benefs: 0,
-    benefsOptions: { min: 0, max: 500000, minLimit: 0, maxLimit: false, ticks: 10000, unit: '€' },
+    benefsOptions: { min: 0, max: 500000, minLimit: 0, maxLimit: false, ticks: 10000, unit: '€', translateUnit: false },
 
     reserves: 40,
     participation: 50,
     dividendes: 10,
-    reservesOptions: { min: 10, max: 80, minLimit: 16, maxLimit: 75, ticks: 5, unit: '%', substract: 'participation' },
-    participationOptions: { min: 20, max: 90, minLimit: 25, maxLimit: 84, ticks: 5, unit: '%', substract: 'reserves' },
-    dividendesOptions: { min: 0, max: 40, minLimit: 0, maxLimit: 33, ticks: 5, unit: '%', substract: 'reserves' },
+    reservesOptions: { min: 10, max: 80, minLimit: 16, maxLimit: 75, ticks: 5, unit: '%', translateUnit: false, substract: 'participation' },
+    participationOptions: { min: 20, max: 90, minLimit: 25, maxLimit: 84, ticks: 5, unit: '%', translateUnit: false, substract: 'reserves' },
+    dividendesOptions: { min: 0, max: 40, minLimit: 0, maxLimit: 33, ticks: 5, unit: '%', translateUnit: false, substract: 'reserves' },
 
-    workTimeOptions: { min: 0, max: 100, minLimit: 0, maxLimit: 100, ticks: 5, unit: '%' },
-    yearTimeOptions: { min: 0, max: 12, minLimit: 0, maxLimit: 12, ticks: 1, unit: 'months' },
-    partsOptions: { min: 0, max: 200, minLimit: 0, maxLimit: 200, ticks: 10, unit: 'partsShort' },
+    workTimeOptions: { min: 0, max: 100, minLimit: 0, maxLimit: 100, ticks: 5, unit: '%', translateUnit: false },
+    yearTimeOptions: { min: 0, max: 12, minLimit: 0, maxLimit: 12, ticks: 1, unit: 'months', translateUnit: true },
+    partsOptions: { min: 0, max: 200, minLimit: 0, maxLimit: 200, ticks: 10, unit: 'partsShort', translateUnit: true },
 
     repartDefaults: {},
     repartNeedsReset: [],

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -165,10 +165,10 @@ export default new Vuex.Store({
     },
     getTranslation: (state) => (key) => {
       return state.dict[key][state.locale] || key
+    },
+    getMemberDefault: (state) => (keyMember) => {
+      return state.teamMembersDefault.find(m => m.key === keyMember)
     }
-    // getMemberDefault: (state) => (keyMember) => {
-    //   return state.teamMembersDefault.find(m => m.key === keyMember)
-    // }
   },
   mutations: {
     setValue (state, { space, value }) {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -56,13 +56,13 @@ export default new Vuex.Store({
         fr: 'Réserves impartageables'
       },
       participation: {
-        fr: 'Participation aux salarié·e·s'
+        fr: 'Participation brute aux salarié·e·s'
       },
       participationSingular: {
         fr: 'Prime de participation'
       },
       dividendes: {
-        fr: 'Dividendes'
+        fr: 'Intérêts aux parts'
       },
       totalShares: {
         fr: 'Total de part aux bénéfices'

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -22,6 +22,8 @@ export default new Vuex.Store({
     dividendesOptions: { min: 0, max: 40, minLimit: 0, maxLimit: 33, ticks: 5, unit: '%', substract: 'reserves' },
 
     workTimeOptions: { min: 0, max: 100, minLimit: 0, maxLimit: 100, ticks: 5, unit: '%' },
+    yearTimeOptions: { min: 0, max: 12, minLimit: 0, maxLimit: 12, ticks: 1, unit: 'months' },
+    partsOptions: { min: 0, max: 200, minLimit: 0, maxLimit: 200, ticks: 10, unit: 'partsShort' },
 
     repartDefaults: {},
     repartNeedsReset: [],
@@ -45,6 +47,9 @@ export default new Vuex.Store({
       },
       close: {
         fr: 'Fermer'
+      },
+      editValue: {
+        fr: 'Éditer la valeur'
       },
       code: {
         fr: 'Code source'

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -12,7 +12,7 @@ export default new Vuex.Store({
     partValueOptions: { min: 10, max: 80, minLimit: 20, maxLimit: 75, ticks: 5, unit: '€', translateUnit: false },
 
     benefs: 0,
-    benefsOptions: { min: 0, max: 500000, minLimit: 0, maxLimit: false, ticks: 10000, unit: '€', translateUnit: false },
+    benefsOptions: { min: 0, max: 200000, minLimit: 0, maxLimit: false, ticks: 500, unit: '€', translateUnit: false },
 
     reserves: 40,
     participation: 50,
@@ -40,7 +40,7 @@ export default new Vuex.Store({
 
     dict: {
       title: {
-        fr: 'Simulateur de répartition des excédents de gestion de la coopérative'
+        fr: 'Simulateur de répartition des excédents nets de gestion de la coopérative'
       },
       reclaim: {
         fr: 'Un widget open source codé par'
@@ -70,7 +70,7 @@ export default new Vuex.Store({
         fr: 'Intérêts aux parts'
       },
       totalShares: {
-        fr: 'Total de part aux bénéfices'
+        fr: 'Total de part aux excédents nets de gestion'
       },
       name: {
         fr: 'Nom'


### PR DESCRIPTION
linked to https://github.com/multi-coop/multi-site-simulator/issues/10

- **updates édito**
  - [x] Utiliser le mot « Intérêts aux parts » plutôt que « Dividendes »
  - [x] Indiquer « Participation brute aux salariés » et non pas « Participation aux salariés »
- **ajout de feature**
  - [x] Donner la possibilité d’un % exact, à l’unité donc, et non pas de 5% en 5% => ajout et généralisation de l''usage du composant slider, avec un bouton à côté du label pour switcher entre vue slider et édition du chiffre à l'unité en direct
